### PR TITLE
Add `-dependencies` option to reference grammars that their input grammars rely on

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Generate a single test-case and print it to `stdout`. Multiple grammars can be a
 dharma -grammars dharma/grammars/canvas2d.dg
 ```
 
+Generate a single test-case where the input grammar reference rules in other grammars
+```bash
+dharma -grammars input_grammar.dg -dependencies reference_grammar_path
+```
+
 Generating multiple test-cases and save the result to disk.
 
 ```bash

--- a/dharma/dharma.py
+++ b/dharma/dharma.py
@@ -8,6 +8,7 @@ import os
 import random
 import struct
 import sys
+from pathlib import Path
 
 from .__version__ import __version__, __title__
 from .core.dharma import DharmaMachine
@@ -51,6 +52,8 @@ class DharmaCommandLine:
         o.add_argument('-template', metavar='file', type=argparse.FileType(), help='template data')
         o.add_argument('-version', action='version', version='%(prog)s {}'.format(__version__),
                        help=argparse.SUPPRESS)
+        o.add_argument('-dependencies', metavar='path', type=Path,
+                       help='path containing grammars referenced by input grammars')
 
         return parser.parse_args()
 
@@ -68,7 +71,7 @@ class DharmaCommandLine:
         template_data = '' if not args.template else args.template.read()
         dharma = DharmaMachine(prefix_data, suffix_data, template_data)
         dharma.process_settings(args.settings)
-        dharma.process_grammars(args.grammars)
+        dharma.process_grammars(args.grammars, args.dependencies)
         if args.storage:
             dharma.generate_testcases(args.storage, args.format, args.count)
         elif args.server:


### PR DESCRIPTION
### Background

Currently it is not possible for a user to reference a rule from a grammar not in `dharma/grammars` unless they edit [`DharmaMachine.default_grammars`](https://github.com/posidron/dharma/blob/c0fc27495abc342be207f9e4472ec4dc1ef6e425/dharma/core/dharma.py#L221) to include the path to the grammar files they want to reference. In this patch, we add support for users to reference rules in other files or directories in their input grammar files using the `-dependencies` option. `-dependencies` accepts both files and directories of dharma grammar files. The `-dependencies` option prioritizes definitions in `default_grammars` over user defined dependent grammars to make resolving redefinition errors easier.

### Example Usage
`python3 -m dharma -g input_grammar.dg -d reference_grammar.dg`

```input_grammar.dg
...
%section% := value

definition :=
    +reference_grammar:dependency+
...
```

```reference_grammar.dg
...
%section% := value

dependency :=
    "This is a rule input_grammar references in its grammar"
...
```